### PR TITLE
feat(RM-76): Custom activity status

### DIFF
--- a/model/src/user/activity.rs
+++ b/model/src/user/activity.rs
@@ -49,6 +49,12 @@ pub struct Activity {
 
 impl Activity {
     pub fn new(name: String, activity_type: ActivityType) -> Activity {
+        let state = if activity_type == ActivityType::Custom {
+            Some(name.clone())
+        } else {
+            None
+        };
+
         Activity {
             name,
             activity_type,
@@ -57,7 +63,7 @@ impl Activity {
             timestamps: None,
             application_id: None,
             details: None,
-            state: None,
+            state,
             emoji: None,
             party: None,
             assets: None,


### PR DESCRIPTION
This pull request updates the `Activity` struct in `model/src/user/activity.rs` to dynamically set the `state` field based on the `activity_type`. The changes improve how the `state` field is initialized, particularly for custom activities.

Key changes:

### Enhancements to `Activity` initialization:
* Added logic in the `new` method of the `Activity` struct to set the `state` field to the `name` value if the `activity_type` is `ActivityType::Custom`. Otherwise, the `state` is set to `None`. ([`model/src/user/activity.rsR52-R57`](diffhunk://#diff-55a828956548f215bab3e5b2e85ea37723eae2288f344d914199e252ed0d327dR52-R57))
* Updated the initialization of the `state` field in the `Activity` struct to use the newly added logic. ([`model/src/user/activity.rsL60-R66`](diffhunk://#diff-55a828956548f215bab3e5b2e85ea37723eae2288f344d914199e252ed0d327dL60-R66))