### PR TITLE
Update Dockerfiles to use Debian and Rust bullseye images

### DIFF
--- a/bot-list-updater/Dockerfile
+++ b/bot-list-updater/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster AS builder
+FROM rust:1-bullseye AS builder
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install git openssl libssl-dev ca-certificates cmake
 
@@ -10,7 +10,7 @@ COPY . .
 RUN cargo build --release --bin bot_list_updater
 
 # Prod container
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 

--- a/cache/Dockerfile
+++ b/cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster AS builder
+FROM rust:1-bullseye AS builder
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install git openssl libssl-dev ca-certificates cmake
 
@@ -10,7 +10,7 @@ COPY . .
 RUN cargo build --release --bin cache
 
 # Prod container
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 

--- a/image-proxy/Dockerfile
+++ b/image-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster
+FROM rust:1-bullseye
 
 RUN apt-get install -y apt-transport-https
 RUN apt-get update && apt-get -y upgrade && apt-get -y install python3 openssl libssl-dev ca-certificates cmake
@@ -11,7 +11,7 @@ COPY . .
 RUN cargo build --release --bin image-proxy
 
 # Prod container
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 

--- a/patreon-proxy/Dockerfile
+++ b/patreon-proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster AS builder
+FROM rust:1-bullseye AS builder
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install git openssl libssl-dev ca-certificates cmake
 
@@ -10,7 +10,7 @@ COPY . .
 RUN cargo build --release --bin patreon-proxy
 
 # Prod container
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 

--- a/server-counter/Dockerfile
+++ b/server-counter/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster
+FROM rust:1-bullseye
 
 RUN apt-get install -y apt-transport-https
 RUN apt-get update && apt-get -y upgrade && apt-get -y install python3 openssl libssl-dev ca-certificates cmake
@@ -10,7 +10,7 @@ COPY . .
 
 RUN cargo build --release --bin server_counter
 
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 

--- a/vote_listener/Dockerfile
+++ b/vote_listener/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1-buster AS builder
+FROM rust:1-bullseye AS builder
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install git openssl libssl-dev ca-certificates cmake
 
@@ -10,7 +10,7 @@ COPY . .
 RUN cargo build --release --bin vote_listener
 
 # Prod container
-FROM debian:buster
+FROM debian:bullseye
 
 RUN apt-get update && apt-get -y upgrade && apt-get -y install openssl libssl-dev ca-certificates
 


### PR DESCRIPTION
## Description
Switched all Dockerfiles from buster-based to bullseye-based Rust and Debian images for both build and production stages. This update ensures compatibility with newer dependencies and provides improved security and support.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Testing
Can you build the image before this change? no, can you build the image after this change? yes (i tested with server-counter)

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
