### PR TITLE
Make CORS origin configurable via env var

### DIFF
--- a/server-counter/envvars.md
+++ b/server-counter/envvars.md
@@ -1,2 +1,3 @@
 - SERVER_ADDR
 - CACHE_URI
+- CORS_ORIGIN (optional, defaults to https://tickets.bot)

--- a/server-counter/src/http/routes/total.rs
+++ b/server-counter/src/http/routes/total.rs
@@ -6,6 +6,7 @@ use axum::http::{HeaderMap, HeaderValue};
 use axum::response::Json;
 use cache::Cache;
 use hyper::http::StatusCode;
+use std::env;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
@@ -14,10 +15,13 @@ pub async fn total_handler<T: Cache>(
 ) -> (StatusCode, HeaderMap, Json<Response>) {
     let count = server.0.count.load(Ordering::Relaxed);
 
+    let origin = env::var("CORS_ORIGIN")
+        .unwrap_or_else(|_| "https://tickets.bot".to_string());
+
     let mut headers = HeaderMap::new();
     headers.insert(
         ACCESS_CONTROL_ALLOW_ORIGIN,
-        HeaderValue::from_static("https://tickets.bot"),
+        HeaderValue::from_str(&origin).expect("Invalid CORS_ORIGIN"),
     );
 
     let body = Response::success(count);


### PR DESCRIPTION
## Description
Added support for a CORS_ORIGIN environment variable to configure the allowed CORS origin, defaulting to https://tickets.bot if not set.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change

## Testing
Not setting the CORS_ORIGIN environment variable defaults to https://tickets.bot, setting the CORS_ORIGIN environment variable allows said origin

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
