### PR TITLE
Add optional required flag to interaction components

### DIFF
--- a/model/src/interaction/input_text.rs
+++ b/model/src/interaction/input_text.rs
@@ -12,6 +12,8 @@ pub struct InputText {
     pub min_length: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_length: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, Deserialize_repr, Serialize_repr)]

--- a/model/src/interaction/select_menu.rs
+++ b/model/src/interaction/select_menu.rs
@@ -19,6 +19,8 @@ pub struct SelectMenu {
     pub max_values: u8,
     #[serde(default = "Default::default")]
     pub disabled: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub required: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## Description
Add an Option<bool> field named `required` to the InputText and SelectMenu structs, using serde's skip_serializing_if = Option::is_none. This allows these interaction components to include an explicit required flag when present without changing existing serialized output when absent.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist
- [x] My code follows the style of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
